### PR TITLE
fix set system hostname typo avoiding HostnameApi to be called.

### DIFF
--- a/config/command.go
+++ b/config/command.go
@@ -350,7 +350,7 @@ func (this *CliComponent) Start() component.Component {
 	run := mode.Parser.Lookup("run")
 	run.LinkNodes(opNode)
 
-	Parser.InstallLine("system host-name WORD", HostnameApi)
+	Parser.InstallLine("system hostname WORD", HostnameApi)
 	Parser.InstallLine("system etcd endpoints WORD", EtcdEndpointsApi)
 	Parser.InstallLine("system etcd path WORD", EtcdPathApi)
 	Parser.InstallLine("interfaces interface WORD dhcp-relay-group WORD", RelayApi)


### PR DESCRIPTION
`HostnameApi` was not called when committing `set system hostname host1` due to a typo.
After this change, `HostnameApi` will be called and change hostname as below.

Log with this change.

```
coreswitch>configure
coreswitch#set system hostname host1
coreswitch#commit
coreswitch#hostname
host1
coreswitch#del system hostname host1
coreswitch#commit
coreswitch#hostname
coreswitch
coreswitch#
```