### PR TITLE
cli: support changing prompt per console

### DIFF
--- a/bash_completion.d/cli
+++ b/bash_completion.d/cli
@@ -61,7 +61,11 @@ _cli_prompt_setup ()
     CLI_MODE_CHAR="#"
   fi
 
-  export PS1="$(hostname)${CLI_MODE_PROMPT}${CLI_MODE_CHAR}"
+  if [ -n $CLI_PROMPT ]; then
+    export PS1="${CLI_PROMPT}${CLI_MODE_PROMPT}${CLI_MODE_CHAR}"
+  else
+    export PS1="$(hostname)${CLI_MODE_PROMPT}${CLI_MODE_CHAR}"
+  fi
 }
 
 _cli_pager_setup ()


### PR DESCRIPTION
Currently, CLI prompt string consists of $(hostname)${CLI_MODE_PROMPT}${CLI_MODE_CHAR}.
This makes it difficult to identify which console you are in when having a couple of them.
For example, if you are using netns to run multiple openconfigd/ribd on virtual hosts, changing hostname via `set system hostname <hostname>` will cause prompt of all netns to change.

With this change, you will be able to change prompt string per console session (env).

Example running cli in 3 different consoles.
```
ebiken@coreswitch:~$ env CLI_PROMPT=console1 cli
console1>
console1>configure
console1#exit
console1>

ebiken@coreswitch:~$ env CLI_PROMPT=console2 cli
console2>
console2>configure
console2#exit
console2>

ebiken@coreswitch:~$ ip netns exec host1 CLI_PROMPT=host1 cli
host1>
host1>configure
host1#exit
host1>
```