### PR TITLE
Fixed a bug how SubscribeMutex is used.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -846,6 +846,9 @@ func (c *Config) WriteTo(path string, by ...string) {
 }
 
 func ConfigDiscard() bool {
+	SubscribeMutex.Lock()
+	defer SubscribeMutex.Unlock()
+
 	diff := CompareCommand()
 	if diff != "" {
 		configCandidate = configActive.Copy(nil)

--- a/config/yang.go
+++ b/config/yang.go
@@ -150,6 +150,9 @@ func YangConfigPull(Args []string) {
 }
 
 func YParseSet(param *cmd.Param) (int, cmd.Callback, []interface{}, cmd.CompSlice) {
+	SubscribeMutex.Lock()
+	defer SubscribeMutex.Unlock()
+
 	// Trim "set"
 	if len(param.Command) > 0 {
 		param.Command = param.Command[1:]
@@ -168,8 +171,6 @@ func YParseSet(param *cmd.Param) (int, cmd.Callback, []interface{}, cmd.CompSlic
 
 func ProcessDelete(config *Config) {
 	//fmt.Println("SubscribeMutex.Lock ProcessDelete")
-	SubscribeMutex.Lock()
-	defer SubscribeMutex.Unlock()
 	Delete(config, true)
 }
 
@@ -780,6 +781,9 @@ func ParseDelete(cmds []string, config *Config, s *YMatchState) (int, cmd.Callba
 }
 
 func YParseDelete(param *cmd.Param) (int, cmd.Callback, []interface{}, cmd.CompSlice) {
+	SubscribeMutex.Lock()
+	defer SubscribeMutex.Unlock()
+
 	// Trim "delete"
 	if len(param.Command) > 0 {
 		param.Command = param.Command[1:]


### PR DESCRIPTION
I think the following functions need to use **SubscriberMutex** because they touch **configCandidate** and 

- ConfigDiscard()
- YParseSet()
- YParseDelete()

At the same time, need to remove the use of **SubscriberMutex** from ProcessDelete() since it does not touch **configCandidate** directly (YParseDelete() takes care of protecting it, instead.)
